### PR TITLE
ヘッダーのサイズを修正した

### DIFF
--- a/kadai.css
+++ b/kadai.css
@@ -88,7 +88,7 @@ header nav {
     z-index: 1;
     background-color: rgb(0, 0, 0, 0.5);
     height: 80px;
-    width: 100vw;;
+    width: 100%;
 }
 
 header .navbar-brand img {


### PR DESCRIPTION
### 変更内容
ヘッダーのサイズを修正した
| before | after |
|--------|-------|
|<img width="692" alt="スクリーンショット 2020-03-18 18 51 27" src="https://user-images.githubusercontent.com/50036617/76949005-3de36d80-694b-11ea-806f-6a6537b8e02c.png">|<img width="692" alt="スクリーンショット 2020-03-18 18 51 01" src="https://user-images.githubusercontent.com/50036617/76948986-38862300-694b-11ea-88a7-0f976cd06259.png">|

### 変更理由
100vwはスクロールバーを常に表示してるユーザーのスクロールバーとかぶるため

### 動作確認URL